### PR TITLE
11 portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,3 +379,49 @@ export default ErrorBoundary;
   <div id="modal"></div> 
 </body>
 ```
+
+#### Create a Modal Container
+```javascript
+import React, { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+const modalRoot = document.getElementById("modal");
+
+const Modal = ({ children }) => {
+  const elRef = useRef(null);
+  if (!elRef.current) {
+    elRef.current = document.createElement("div");
+  }
+
+  useEffect(() => {
+    modalRoot.appendChild(elRef.current);
+    return () => modalRoot.removeChild(elRef.current);
+  }, []);
+
+  return createPortal(<div>{children}</div>, elRef.current);
+};
+
+export default Modal;
+```
+
+#### Apply Modal
+```javascript
+  toggleModal() {
+    this.setState({ showModal: !this.state.showModal });
+  }
+  adopt() {
+    navigate(this.state.url);
+  }
+
+  {showModal ? (
+    <Modal>
+      <div>
+        <h1>Would you like to adopt {name}?</h1>
+        <div className="buttons">
+          <button onClick={this.adopt}>Yes</button>
+          <button onClick={this.toggleModal}>No</button>
+        </div>
+      </div>
+    </Modal>
+  ) : null}
+```

--- a/README.md
+++ b/README.md
@@ -361,3 +361,21 @@ export default ErrorBoundary;
 - Application-Level State, **avoid using context until you have to use it**.
 - Use `Redux` or `Context`, don't use them both.
 - Context is useful to pass `broadcasting` **user-data**
+
+
+### Context
+- Application-Level State, **avoid using context until you have to use it**.
+- Use `Redux` or `Context`, don't use them both.
+- Context is useful to pass `broadcasting` **user-data**
+
+### Portal
+- usually used to do modal
+#### Create A new Mount Point
+- This where the modal will actually be mounted whenever we render to this portal. **Totally separate from our app root**.
+```html
+<body>
+  <div id="root">Not Rendered!</div>
+  <!-- Second Mount Point -->
+  <div id="modal"></div> 
+</body>
+```

--- a/src/Details.js
+++ b/src/Details.js
@@ -3,12 +3,18 @@ import pet from '@frontendmasters/pet';
 import Carousel from './Carousel';
 import ErrorBoundary from './ErrorBoundary';
 import ThemeContext from './ThemeContext';
+import { navigate } from '@reach/router';
+import Modal from './Modal';
+
 class Details extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       loading: true,
+      showModal: false,
     };
+    this.toggleModal = this.toggleModal.bind(this);
+    this.adopt = this.adopt.bind(this);
   }
 
   componentDidMount() {
@@ -22,8 +28,16 @@ class Details extends React.Component {
         media: animal.photos,
         breed: animal.breeds.primary,
         loading: false,
+        url: animal.url,
       });
     });
+  }
+
+  toggleModal() {
+    this.setState({ showModal: !this.state.showModal });
+  }
+  adopt() {
+    navigate(this.state.url);
   }
 
   render() {
@@ -31,7 +45,15 @@ class Details extends React.Component {
       return <h1>Loading</h1>;
     }
 
-    const { name, animal, location, description, media, breed } = this.state;
+    const {
+      name,
+      animal,
+      location,
+      description,
+      media,
+      breed,
+      showModal,
+    } = this.state;
     return (
       <div className="details">
         <Carousel media={media} />
@@ -42,13 +64,24 @@ class Details extends React.Component {
             {([theme]) => (
               <button
                 style={{ backgroundColor: theme }}
-                // onClick={this.toggleModal}
+                onClick={this.toggleModal}
               >
                 Adopt {name}
               </button>
             )}
           </ThemeContext.Consumer>
-          ;<p>{description}</p>
+          <p>{description}</p>
+          {showModal ? (
+            <Modal>
+              <div>
+                <h1>Would you like to adopt {name}?</h1>
+                <div className="buttons">
+                  <button onClick={this.adopt}>Yes</button>
+                  <button onClick={this.toggleModal}>No</button>
+                </div>
+              </div>
+            </Modal>
+          ) : null}
         </div>
       </div>
     );

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,0 +1,20 @@
+import React, { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+const modalRoot = document.getElementById("modal");
+
+const Modal = ({ children }) => {
+  const elRef = useRef(null);
+  if (!elRef.current) {
+    elRef.current = document.createElement("div");
+  }
+
+  useEffect(() => {
+    modalRoot.appendChild(elRef.current);
+    return () => modalRoot.removeChild(elRef.current);
+  }, []);
+
+  return createPortal(<div>{children}</div>, elRef.current);
+};
+
+export default Modal;


### PR DESCRIPTION
### Portal
- usually used to do modal
#### Create A new Mount Point
- This where the modal will actually be mounted whenever we render to this portal. **Totally separate from our app root**.
```html
<body>
  <div id="root">Not Rendered!</div>
  <!-- Second Mount Point -->
  <div id="modal"></div> 
</body>
```

#### Create a Modal Container
```javascript
import React, { useEffect, useRef } from "react";
import { createPortal } from "react-dom";

const modalRoot = document.getElementById("modal");

const Modal = ({ children }) => {
  const elRef = useRef(null);
  if (!elRef.current) {
    elRef.current = document.createElement("div");
  }

  useEffect(() => {
    modalRoot.appendChild(elRef.current);
    return () => modalRoot.removeChild(elRef.current);
  }, []);

  return createPortal(<div>{children}</div>, elRef.current);
};

export default Modal;
```

#### Apply Modal
```javascript
  toggleModal() {
    this.setState({ showModal: !this.state.showModal });
  }
  adopt() {
    navigate(this.state.url);
  }

  {showModal ? (
    <Modal>
      <div>
        <h1>Would you like to adopt {name}?</h1>
        <div className="buttons">
          <button onClick={this.adopt}>Yes</button>
          <button onClick={this.toggleModal}>No</button>
        </div>
      </div>
    </Modal>
  ) : null}
```